### PR TITLE
refactor: Set side of keywizard to CLIENT for Forge and Minecraft

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -45,11 +45,11 @@ mandatory = true # do you **need** this mod to be able to launch?
 # Brackets mean "inclusive" bounds, while parentheses mean "exclusive".
 versionRange = "[36,)" # This essentially means any forge >= 36
 ordering = "NONE" # Use this if you want your mod to be loaded specifically BEFORE or AFTER another mod
-side = "BOTH" # Specify where this mod is required: can be BOTH, CLIENT or SERVER
+side = "CLIENT" # Specify where this mod is required: can be BOTH, CLIENT or SERVER
 
 [[dependencies.keywizard]]
 modId = "minecraft"
 mandatory = true
 versionRange = "[1.16.5,1.17)"
 ordering = "NONE"
-side = "BOTH"
+side = "CLIENT"


### PR DESCRIPTION
A small change in the [[dependencies.keywizard]] declaration which reflects the actual side of the mod when used. This will help ServerPackCreator identify the sideness in future upates.

For reference: Griefed/ServerPackCreator#70

Please let me know if you have any issues with this.

Cheers,
Griefed